### PR TITLE
BrokenBuildMessage was missing

### DIFF
--- a/Bugle/Helpers/BrokenBuildMessage.cs
+++ b/Bugle/Helpers/BrokenBuildMessage.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SevanConsulting.Bugle.Helpers
+{
+    public class BrokenBuildMessage
+    {
+        public string BuildDefinitionName { get; set; }
+        public string BuildNumber { get; set; }
+        public DateTime? BuildDate { get; set; }
+    }
+}


### PR DESCRIPTION
I just added the object and thought I would try a pull request. I get it to build, not saying it runs :)

BuildNumber is a string and DateTime stamp needed to be nullable right?
